### PR TITLE
pkg/config: check if globally excluded members belong to the org

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,5 +103,10 @@ func SanityCheck(cfg *Config) error {
 			}
 		}
 	}
+	for _, xMember := range cfg.ExcludeCRAFromAllTeams {
+		if _, ok := cfg.Members[xMember]; !ok {
+			return fmt.Errorf("member %q from globally excluded reviews, does not belong to the organization", xMember)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Fixes: 874fe77169aa ("check if members in teams belong to the organization")
Signed-off-by: André Martins <andre@cilium.io>