### PR TITLE
pkg/config: Support slackID field

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Done, change your local configuration and re-run me again.
 
 ```yaml
 organization: cilium
+slackWorkspace: isovalent.slack.com
 # List of members that belong to the organization, ordered by GitHub login (username).
 members:
   aanm:
@@ -51,6 +52,8 @@ members:
     id: MDQ6VXNlcjU3MTQwNjY=
     # User real name, useful to know which person is behind a GitHub username.
     name: André Martins
+    # Slack user ID, to ping folks on Slack.
+    slackId: U3Z10R6HW
   borkmann:
     id: MDQ6VXNlcjY3NzM5Mw==
     name: Daniel Borkmann

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	// Organization being managed.
 	Organization string `json:"organization,omitempty" yaml:"organization,omitempty"`
 
+	// URL of the Slack workspace to which the Slack user IDs belong.
+	SlackWorkspace string `json:"slackWorkspace,omitempty" yaml:"slackWorkspace,omitempty"`
+
 	// Members maps the github login to a User.
 	Members map[string]User `json:"members,omitempty" yaml:"members,omitempty"`
 
@@ -50,6 +53,10 @@ type User struct {
 
 	// Name is the real name of the person behind this GH account.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// SlackID is the Slack user ID of the person behind this GH account.
+	// The user ID can be found in the UI, under the profile of each user, under "More".
+	SlackID string `json:"slackID,omitempty" yaml:"slackID,omitempty"`
 }
 
 type ExcludedMember struct {

--- a/team-assignments.yaml
+++ b/team-assignments.yaml
@@ -1,4 +1,5 @@
 organization: cilium
+slackWorkspace: isovalent.slack.com
 # List of members that belong to the organization, ordered by GitHub login (username).
 members:
   aanm:
@@ -6,6 +7,8 @@ members:
     id: MDQ6VXNlcjU3MTQwNjY=
     # User real name, useful to know which person is behind a GitHub username.
     name: André Martins
+    # Slack user ID, to ping folks on Slack.
+    slackId: U3Z10R6HW
   borkmann:
     id: MDQ6VXNlcjY3NzM5Mw==
     name: Daniel Borkmann


### PR DESCRIPTION
This new field will be used to ping users on Slack. Team manager only needs to know about it to allow it in the configuration file; it's not used by Team manager itself.