### PR TITLE
Revert "config: Introduce `reason` field in global exclude"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ teams:
 # that they belong. This list can exist for numerous reasons, person is
 # currently PTO or busy with other work.
 excludeCodeReviewAssignmentFromAllTeams:
-- login: borkmann
-  reason: PTO
+- borkmann
 ```
 
 4. Once the changes stored in a local configuration file, re-run `./team-manager`:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 
 	// Slice of github logins that should be excluded from all team reviews
 	// assignments.
-	ExcludeCRAFromAllTeams []ExcludedMember `json:"excludeCodeReviewAssignmentFromAllTeams" yaml:"excludeCodeReviewAssignmentFromAllTeams"`
+	ExcludeCRAFromAllTeams []string `json:"excludeCodeReviewAssignmentFromAllTeams" yaml:"excludeCodeReviewAssignmentFromAllTeams"`
 }
 
 type TeamConfig struct {
@@ -104,7 +104,7 @@ func SanityCheck(cfg *Config) error {
 		}
 	}
 	for _, xMember := range cfg.ExcludeCRAFromAllTeams {
-		if _, ok := cfg.Members[xMember.Login]; !ok {
+		if _, ok := cfg.Members[xMember]; !ok {
 			return fmt.Errorf("member %q from globally excluded reviews, does not belong to the organization", xMember)
 		}
 	}

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -44,8 +44,5 @@ func SortConfig(cfg *Config) {
 		cfg.Teams[teamName] = team
 	}
 	// Sort excluded team members
-	sort.Slice(cfg.ExcludeCRAFromAllTeams, func(i, j int) bool {
-		return cfg.ExcludeCRAFromAllTeams[i].Login <
-			cfg.ExcludeCRAFromAllTeams[j].Login
-	})
+	sort.Strings(cfg.ExcludeCRAFromAllTeams)
 }

--- a/pkg/team/manager.go
+++ b/pkg/team/manager.go
@@ -302,7 +302,7 @@ func (tm *Manager) SyncTeams(ctx context.Context, localCfg *config.Config, force
 
 // getExcludedUsers returns a list of all users that should be excluded for the
 // given team.
-func getExcludedUsers(teamName string, members map[string]config.User, excTeamMembers []config.ExcludedMember, excAllTeams []config.ExcludedMember) []githubv4.ID {
+func getExcludedUsers(teamName string, members map[string]config.User, excTeamMembers []config.ExcludedMember, excAllTeams []string) []githubv4.ID {
 	m := make(map[githubv4.ID]struct{}, len(excTeamMembers)+len(excAllTeams))
 	for _, member := range excTeamMembers {
 		user, ok := members[member.Login]
@@ -313,7 +313,7 @@ func getExcludedUsers(teamName string, members map[string]config.User, excTeamMe
 		m[user.ID] = struct{}{}
 	}
 	for _, member := range excAllTeams {
-		user, ok := members[member.Login]
+		user, ok := members[member]
 		if !ok {
 			// Ignore if it doesn't belong to the team
 			continue

--- a/team-assignments.yaml
+++ b/team-assignments.yaml
@@ -53,5 +53,4 @@ teams:
 # that they belong. This list can exist for numerous reasons, person is
 # currently PTO or busy with other work.
 excludeCodeReviewAssignmentFromAllTeams:
-- login: borkmann
-  reason: PTO
+- borkmann


### PR DESCRIPTION
This reverts PR #6 

The PR was build-able when it was created - but it was merged over 6 months later, at which point it no longer worked. We should avoid merging PRs without a recent CI run, even if the old CI run is green (as was the case).