### PR TITLE
Docker build target will now build multiarch image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM docker.io/library/golang:1.18.1@sha256:12d3995156cb0dcdbb9d3edb5827e4e8e1bf
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/team-manager
 WORKDIR /go/src/github.com/cilium/team-manager
+ARG TARGETARCH
 RUN make team-manager
 RUN strip team-manager
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
+BUILD_VARS=CGO_ENABLED=0 GOARCH=${TARGETARCH}
+IMAGE=cilium/team-manager
+VERSION=latest
+
 all: local
 
 docker-image:
-	docker build -t cilium/team-manager:${VERSION} .
+	docker buildx build --push --builder default -t $(IMAGE):$(VERSION) .
 
 tests:
-	go test -mod=vendor ./...
+	$(BUILD_VARS) go test -mod=vendor ./...
 
 team-manager: tests
-	CGO_ENABLED=0 go build -mod=vendor -a -installsuffix cgo -o $@ ./cmd/main.go
+	$(BUILD_VARS) go build -mod=vendor -a -installsuffix cgo -o $@ ./cmd/main.go
 
 local: team-manager
 	strip team-manager


### PR DESCRIPTION
Will build for arm64/amd64.

Not sure how the official image is built, is this just done manually by someone?

Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>