### PR TITLE
tophat: set tophat only if defined

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -131,8 +131,11 @@ func run(cmd *cobra.Command, args []string) {
 			panic(err)
 		}
 
-		if err = setTeamMembers("tophat", setTopHat, newConfig); err != nil {
-			panic(err)
+		if len(setTopHat) > 0 {
+			if err = setTeamMembers("tophat", setTopHat, newConfig); err != nil {
+
+				panic(err)
+			}
 		}
 
 		if err = addCRAExclusionToConfig(addPTO, newConfig); err != nil {


### PR DESCRIPTION
TopHat members should only replace the current list of tophat members if they a list of tophat members are explicitly set via `set-top-hat`.

Otherwise the list of members is replaced with an empty list during linting.

Fixes: #13