### PR TITLE
dryrun: disable github token validation during dryrun

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,7 +77,7 @@ func signals() {
 
 func InitState() (localCfg *config.Config, ghClient *gh.Client, err error) {
 	token := os.Getenv("GITHUB_TOKEN")
-	if token == "" {
+	if token == "" && !dryRun {
 		return nil, nil, errGithubToken
 	}
 	ghClient = github.NewClient(token)


### PR DESCRIPTION
GitHub token validation should be disabled during dryrun execution.

Otherwise, a valid GH token is required to perform local linting of the local configuration.

Fixes: https://github.com/cilium/team-manager/pull/13