### PR TITLE
cobra: refactor context propagation and error handling

### DIFF
--- a/cmd/reviews.go
+++ b/cmd/reviews.go
@@ -4,44 +4,50 @@
 package main
 
 import (
-	"github.com/cilium/team-manager/pkg/config"
+	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cilium/team-manager/pkg/config"
 )
 
 var addPTOCmd = &cobra.Command{
 	Use:   "add-pto USER [USER ...]",
 	Short: "Exclude user from code review assignments",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, _, err := InitState()
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("failed to initialize state: %w", err)
 		}
 
 		if err = addCRAExclusionToConfig(args, cfg); err != nil {
-			panic(err)
+			return fmt.Errorf("failed to add code review assignment exclusion: %w", err)
 		}
 		if err = StoreState(cfg); err != nil {
-			panic(err)
+			return fmt.Errorf("failed to store state to config: %w", err)
 		}
+
+		return nil
 	},
 }
 
 var removePTOCmd = &cobra.Command{
 	Use:   "remove-pto USER [USER ...]",
 	Short: "Include user in code review assignments",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, _, err := InitState()
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("failed to initialize state: %w", err)
 		}
 
 		if err := removeCRAExclusionToConfig(args, cfg); err != nil {
-			panic(err)
+			return fmt.Errorf("failed to remove code review assignment exclusion: %w", err)
 		}
 		if err = StoreState(cfg); err != nil {
-			panic(err)
+			return fmt.Errorf("failed to store state to config: %w", err)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -28,7 +28,7 @@ var pullCmd = &cobra.Command{
 			}
 
 			_, _ = fmt.Fprintf(os.Stderr, "Configuration file %q not found, retriving configuration from organization...\n", configFilename)
-			cfg, err = tm.GetCurrentConfig(globalCtx)
+			cfg, err = tm.GetCurrentConfig(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("failed to fetch current config from GitHub: %w", err)
 			}
@@ -59,7 +59,7 @@ var pushCmd = &cobra.Command{
 
 		ghGraphQLClient := github.NewClientGraphQL(os.Getenv("GITHUB_TOKEN"))
 		tm := team.NewManager(ghClient, ghGraphQLClient, orgName)
-		if _, err = tm.SyncTeams(globalCtx, cfg, force); err != nil {
+		if _, err = tm.SyncTeams(cmd.Context(), cfg, force); err != nil {
 			return fmt.Errorf("failed to sync teams to GitHub: %w", err)
 		}
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -6,47 +6,51 @@ package main
 import (
 	"fmt"
 
-	"github.com/cilium/team-manager/pkg/config"
-
 	gh "github.com/google/go-github/v33/github"
 	"github.com/spf13/cobra"
+
+	"github.com/cilium/team-manager/pkg/config"
 )
 
 var addTeamsCmd = &cobra.Command{
 	Use:   "add-team TEAM [TEAM ...]",
 	Short: "Add team to local configuration",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, ghClient, err := InitState()
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("failed to initialize state: %w", err)
 		}
 
 		if err = addTeamsToConfig(args, cfg, ghClient); err != nil {
-			panic(err)
+			return fmt.Errorf("failed to add teams to config: %w", err)
 		}
 		if err = StoreState(cfg); err != nil {
-			panic(err)
+			return fmt.Errorf("failed to store state to config: %w", err)
 		}
+
+		return nil
 	},
 }
 
 var setTeamsUsersCmd = &cobra.Command{
 	Use:   "set-team --team TEAM USER [USER ...]",
 	Short: "Set members of a team in local configuration",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, _, err := InitState()
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("failed to initialize state: %w", err)
 		}
 
 		for _, t := range addTeams {
 			if err = setTeamMembers(t, args, cfg); err != nil {
-				panic(err)
+				return fmt.Errorf("failed to set team members: %w", err)
 			}
 		}
 		if err = StoreState(cfg); err != nil {
-			panic(err)
+			return fmt.Errorf("failed to store state to config: %w", err)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	gh "github.com/google/go-github/v33/github"
@@ -21,7 +22,7 @@ var addTeamsCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize state: %w", err)
 		}
 
-		if err = addTeamsToConfig(args, cfg, ghClient); err != nil {
+		if err = addTeamsToConfig(cmd.Context(), args, cfg, ghClient); err != nil {
 			return fmt.Errorf("failed to add teams to config: %w", err)
 		}
 		if err = StoreState(cfg); err != nil {
@@ -61,9 +62,9 @@ func init() {
 	setTeamsUsersCmd.Flags().StringSliceVar(&addTeams, "teams", []string{}, "Team whose membership should be modified locally")
 }
 
-func addTeamsToConfig(addTeams []string, cfg *config.Config, ghClient *gh.Client) error {
+func addTeamsToConfig(ctx context.Context, addTeams []string, cfg *config.Config, ghClient *gh.Client) error {
 	for _, addTeam := range addTeams {
-		u, _, err := ghClient.Users.Get(globalCtx, addTeam)
+		u, _, err := ghClient.Users.Get(ctx, addTeam)
 		if err != nil {
 			return err
 		}

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -28,7 +29,7 @@ var addUsersCmd = &cobra.Command{
 			}
 		}
 
-		if err = addUsersToConfig(args, cfg, ghClient); err != nil {
+		if err = addUsersToConfig(cmd.Context(), args, cfg, ghClient); err != nil {
 			return fmt.Errorf("failed to add user: %w", err)
 		}
 
@@ -52,9 +53,9 @@ func init() {
 	addUsersCmd.Flags().StringSliceVar(&addTeams, "teams", []string{}, "Add the users to the specified teams in the local cache")
 }
 
-func addUsersToConfig(addUsers []string, cfg *config.Config, ghClient *gh.Client) error {
+func addUsersToConfig(ctx context.Context, addUsers []string, cfg *config.Config, ghClient *gh.Client) error {
 	for _, addUser := range addUsers {
-		u, _, err := ghClient.Users.Get(globalCtx, addUser)
+		u, _, err := ghClient.Users.Get(ctx, addUser)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR refactors context propagation and error handling by using cobra features

**error handling**

Currently, most cobra commands are panic in case of an error without using the provided facility by cobra to properly propagate errors to the user.

This commit refactors the code to returning the errors back to the main by using cobra command.RunE which includes an error as return type of the commands.

This way, the error automatically gets displayed to the user alongside the command information.

**context propagation**

This commit replaces the global context variable with cobra's ability to pass the context via the command.