### PR TITLE
ci: fix tag evaluation script in docker-ci workflow

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           tag="${{ github.sha }}"
 
-          if [[ ${{ github.event.pull_request.head.sha }} != "" ]]; then
+          if [[ "${{ github.event.pull_request.head.sha }}" != "" ]]; then
             echo "Detected PR SHA ${{ github.event.pull_request.head.sha }}"
             tag="${{ github.event.pull_request.head.sha }}"
           fi


### PR DESCRIPTION
This commit fixes the error `conditional binary operator expected` in the tag evaluation step in the docker-ci workflow. This occurs if the variable is empty - which results in an empty string.

https://github.com/mhofstetter/team-manager/actions/runs/5512986922/jobs/10050531790