### PR TITLE
Feature: Team mentor

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ teams:
         - aanm
         - borkmann
         - joestringer
+        # Optional list of team mentors who will not be auto-assigned PRs for review
+        mentors:
+        - aanm
         codeReviewAssignment:
           # algorithm, currently can be LOAD_BALANCE or ROUND_ROBIN.
           algorithm: LOAD_BALANCE

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -39,7 +39,7 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("unable to initialize manager %w", err)
 		}
 
-		if _, err := persistence.LoadState(configFilename); err == nil {
+		if _, err := persistence.LoadState(configFilename, overrideFilename); err == nil {
 			fmt.Printf("Configuration file %q already exists\n", configFilename)
 			return nil
 		} else if !errors.Is(err, os.ErrNotExist) {

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -22,7 +22,7 @@ var checkCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
 
-		localCfg, err := persistence.LoadState(configFilename)
+		localCfg, err := persistence.LoadState(configFilename, overrideFilename)
 		if err != nil {
 			return fmt.Errorf("failed to load local state: %w", err)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,8 +23,9 @@ import (
 )
 
 var (
-	orgName        string
-	configFilename string
+	orgName          string
+	configFilename   string
+	overrideFilename string
 )
 
 func init() {
@@ -32,6 +33,7 @@ func init() {
 
 	flag.StringVar(&orgName, "org", "cilium", "GitHub organization name")
 	flag.StringVar(&configFilename, "config-filename", "team-assignments.yaml", "Config filename")
+	flag.StringVar(&overrideFilename, "override-filename", "", "Team Override filename")
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -37,7 +37,7 @@ var pushCmd = &cobra.Command{
 	Short: "Update team assignments in GitHub from local files",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		cfg, err := persistence.LoadState(configFilename)
+		cfg, err := persistence.LoadState(configFilename, overrideFilename)
 		if err != nil {
 			return fmt.Errorf("failed to load local state: %w", err)
 		}

--- a/cmd/reviews.go
+++ b/cmd/reviews.go
@@ -23,7 +23,7 @@ var addPTOCmd = &cobra.Command{
 	Short: "Exclude user from code review assignments",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := persistence.LoadState(configFilename)
+		cfg, err := persistence.LoadState(configFilename, overrideFilename)
 		if err != nil {
 			return fmt.Errorf("failed to load local state: %w", err)
 		}
@@ -44,7 +44,7 @@ var removePTOCmd = &cobra.Command{
 	Short: "Include user in code review assignments",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := persistence.LoadState(configFilename)
+		cfg, err := persistence.LoadState(configFilename, overrideFilename)
 		if err != nil {
 			return fmt.Errorf("failed to load local state: %w", err)
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -25,7 +25,7 @@ var statusCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
 
-		localCfg, err := persistence.LoadState(configFilename)
+		localCfg, err := persistence.LoadState(configFilename, overrideFilename)
 		if err != nil {
 			return fmt.Errorf("failed to load local state: %w", err)
 		}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -23,7 +23,7 @@ var syncCmd = &cobra.Command{
 	Short: "Merges the configuration from GitHub into the local configuration",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		cfg, err := persistence.LoadState(configFilename)
+		cfg, err := persistence.LoadState(configFilename, overrideFilename)
 		if err != nil {
 			return fmt.Errorf("failed to load local state: %w", err)
 		}

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -36,7 +36,7 @@ var addUsersCmd = &cobra.Command{
 			return fmt.Errorf("failed to create github client: %w", err)
 		}
 
-		cfg, err := persistence.LoadState(configFilename)
+		cfg, err := persistence.LoadState(configFilename, overrideFilename)
 		if err != nil {
 			return fmt.Errorf("failed to load local state: %w", err)
 		}

--- a/pkg/config/sanitycheck.go
+++ b/pkg/config/sanitycheck.go
@@ -30,6 +30,11 @@ func SanityCheck(cfg *Config) error {
 				return fmt.Errorf("member %q from team %q does not belong to organization", member, teamName)
 			}
 		}
+		for _, mentor := range team.Mentors {
+			if _, ok := cfg.Members[mentor]; !ok {
+				return fmt.Errorf("mentor %q from team %q does not belong to organization", mentor, teamName)
+			}
+		}
 		for _, xMember := range team.CodeReviewAssignment.ExcludedMembers {
 			if _, ok := cfg.Members[xMember.Login]; !ok {
 				return fmt.Errorf("member %q from code review assignment of team %q does not belong to organization", xMember.Login, teamName)

--- a/pkg/config/sort.go
+++ b/pkg/config/sort.go
@@ -40,6 +40,18 @@ func SortConfig(cfg *Config) {
 		}
 		sort.Strings(team.Members)
 
+		// Remove and sort and duplicated team mentors
+		teamMentors := make(map[string]struct{}, len(team.Mentors))
+		for _, teamMentor := range team.Mentors {
+			teamMentors[teamMentor] = struct{}{}
+		}
+
+		team.Mentors = make([]string, 0, len(teamMentors))
+		for teamMentor := range teamMentors {
+			team.Mentors = append(team.Mentors, teamMentor)
+		}
+		sort.Strings(team.Mentors)
+
 		// sort excluded members as well
 		sort.Slice(team.CodeReviewAssignment.ExcludedMembers, func(i, j int) bool {
 			return team.CodeReviewAssignment.ExcludedMembers[i].Login <

--- a/pkg/team/push.go
+++ b/pkg/team/push.go
@@ -501,7 +501,7 @@ func (tm *Manager) pushCodeReviewAssignments(ctx context.Context, localCfg *conf
 	for _, teamName := range teamNames {
 		storedTeam := localCfg.AllTeams[teamName]
 		cra := storedTeam.CodeReviewAssignment
-		usersIDs := getExcludedUsers(teamName, localCfg.Members, cra.ExcludedMembers, localCfg.ExcludeCRAFromAllTeams)
+		usersIDs := getExcludedUsers(teamName, localCfg.Members, storedTeam.Mentors, cra.ExcludedMembers, localCfg.ExcludeCRAFromAllTeams)
 
 		input := github.UpdateTeamReviewAssignmentInput{
 			Algorithm:             cra.Algorithm,
@@ -624,6 +624,7 @@ func (tm *Manager) pushMembers(ctx context.Context, force, dryRun bool, localCfg
 
 			for _, team := range localCfg.AllTeams {
 				team.Members = slices.Remove(team.Members, member)
+				team.Mentors = slices.Remove(team.Mentors, member)
 				team.CodeReviewAssignment.ExcludedMembers = config.RemoveExcludedMember(team.CodeReviewAssignment.ExcludedMembers, member)
 			}
 

--- a/pkg/team/utils.go
+++ b/pkg/team/utils.go
@@ -26,8 +26,16 @@ import (
 
 // getExcludedUsers returns a list of all users that should be excluded for the
 // given team.
-func getExcludedUsers(teamName string, members map[string]config.User, excTeamMembers []config.ExcludedMember, excAllTeams []string) []githubv4.ID {
-	m := make(map[githubv4.ID]struct{}, len(excTeamMembers)+len(excAllTeams))
+func getExcludedUsers(teamName string, members map[string]config.User, mentors []string, excTeamMembers []config.ExcludedMember, excAllTeams []string) []githubv4.ID {
+	m := make(map[githubv4.ID]struct{}, len(members)+len(excTeamMembers)+len(excAllTeams))
+	for _, member := range mentors {
+		user, ok := members[member]
+		if !ok {
+			fmt.Printf("[ERROR] mentor %q from team %s, not found in the list of team members in the organization\n", member, teamName)
+			continue
+		}
+		m[user.ID] = struct{}{}
+	}
 	for _, member := range excTeamMembers {
 		user, ok := members[member.Login]
 		if !ok {


### PR DESCRIPTION
This pull request provides a working implementation to make it possible to use team-management tool in a more transparent way for Cilium project team memberships.
 

### Highlights
1. Changes to introduce a mentor list to the TeamConfig to encode team members who want to be excluded from the review notification, simplifying the review exclusion process.

2. Introduction of a team override configuration intended to encode public team member/mentor information on a team by team basis while leaving the full configuration in a private repository. 

3. This is strictly additive changes to how team manager tool operations. It does not interfere with the existing org wide `excludeCodeReviewAssignmentFromAllTeams` config or the team specific `codeReviewAssignment.excludedMembers`.  The intent is that these other mechanisms can be deprecated after configs are converted to using the team mentor concept, to ensure a smooth transition.  Note: the github API doesn't let you query back which userIDs are currently excluded from review, so this is really just a matter of configuration state as a source of truth. 

4. Enhanced user status reporting by the `status` to indicate where in the team management config users are excluded.