### PR TITLE
Tidy up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,24 @@
 VERSION=$(shell git describe --tags --always)
 
-all: local
+.PHONY: all
+all: local test
 
+.PHONY: docker-image
 docker-image:
 	docker build -t cilium/team-manager:${VERSION} .
 
-tests:
+.PHONY: test
+test:
 	go test -mod=vendor ./...
 
-team-manager: tests
+.PHONY: team-manager
+team-manager:
 	CGO_ENABLED=0 go build -mod=vendor -a -installsuffix cgo -o $@ ./cmd/
 
+.PHONY: local
 local: team-manager
 	strip team-manager
 
+.PHONY: clean
 clean:
 	rm -fr team-manager


### PR DESCRIPTION
Tidy up Makefile so it has a standard set of targets all,clean,test.
Move the test dependency into 'all' so that you can do build-only tests
by just 'make team-manager'. Fix up the .PHONY configuration and ensure
that the primary binary is always built since Make isn't aware of the
dependencies.
